### PR TITLE
Fix build for gcc 14 systems on 6.9 kernel

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,6 +53,9 @@ ENABLE_DOUBLE_VLAN = n
 ENABLE_PAGE_REUSE = n
 ENABLE_RX_PACKET_FRAGMENT = n
 
+# GCC 14 will report the following warning as an error and fail to compile. So we need to disable the warning.
+EXTRA_CFLAGS += -Wno-incompatible-pointer-types
+
 ifneq ($(KERNELRELEASE),)
 	obj-m := r8125.o
 	r8125-objs := r8125_n.o rtl_eeprom.o rtltool.o


### PR DESCRIPTION
On my arch linux system,  this module fails to build on 6.9 RC kernel. From what I heard gcc upgraded this warning to Error. Adding `-Wno-incompatible-pointer-types` to Makefile fixes it on my system.

```
$ cat /var/lib/dkms/r8125/9.013.02/build/make.log
DKMS make.log for r8125-9.013.02 for kernel 6.9.0-rc7-5-cachyos-rc (x86_64)
Fri May 10 02:33:33 PM +03 2024
make: Entering directory '/usr/lib/modules/6.9.0-rc7-5-cachyos-rc/build'
  CC [M]  /var/lib/dkms/r8125/9.013.02/build/r8125_n.o
  CC [M]  /var/lib/dkms/r8125/9.013.02/build/rtl_eeprom.o
  CC [M]  /var/lib/dkms/r8125/9.013.02/build/rtltool.o
/var/lib/dkms/r8125/9.013.02/build/r8125_n.c:7682:20: error: initialization of ‘int (*)(struct net_device *, struct ethtool_keee *)’ from incompatible pointer type ‘int (*)(struct net_device *, struct ethtool_eee *)’ [-Wincompatible-pointer-types]
 7682 |         .get_eee = rtl_ethtool_get_eee,
      |                    ^~~~~~~~~~~~~~~~~~~
/var/lib/dkms/r8125/9.013.02/build/r8125_n.c:7682:20: note: (near initialization for ‘rtl8125_ethtool_ops.get_eee’)
/var/lib/dkms/r8125/9.013.02/build/r8125_n.c:7683:20: error: initialization of ‘int (*)(struct net_device *, struct ethtool_keee *)’ from incompatible pointer type ‘int (*)(struct net_device *, struct ethtool_eee *)’ [-Wincompatible-pointer-types]
 7683 |         .set_eee = rtl_ethtool_set_eee,
      |                    ^~~~~~~~~~~~~~~~~~~
/var/lib/dkms/r8125/9.013.02/build/r8125_n.c:7683:20: note: (near initialization for ‘rtl8125_ethtool_ops.set_eee’)
make[2]: *** [scripts/Makefile.build:244: /var/lib/dkms/r8125/9.013.02/build/r8125_n.o] Error 1
make[1]: *** [/usr/lib/modules/6.9.0-rc7-5-cachyos-rc/build/Makefile:1928: /var/lib/dkms/r8125/9.013.02/build] Error 2
make: *** [Makefile:240: __sub-make] Error 2
make: Leaving directory '/usr/lib/modules/6.9.0-rc7-5-cachyos-rc/build'
```